### PR TITLE
Exclude wire generated files, wire_gen.go, from style checks.

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -57,8 +57,14 @@ jobs:
 
       - name: ${{ matrix.tool }} ${{ matrix.options }}
         shell: bash
-        run: |
-          ${{ matrix.tool }} ${{ matrix.options }} -w $(find . -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)
+        run: >
+          ${{ matrix.tool }} ${{ matrix.options }} -w
+          $(find .
+          -path './vendor' -prune
+          -o -path './third_party' -prune
+          -o -name '*.pb.go' -prune
+          -o -name 'wire_gen.go' -prune
+          -o -type f -name '*.go' -print)
 
       - name: Verify ${{ matrix.tool }}
         shell: bash


### PR DESCRIPTION
Exclude wire generated files, `wire_gen.go`, from style checks.

---

This is a copy of https://github.com/knative-sandbox/.github/pull/68